### PR TITLE
Updating to newer gitversion on docker (old one not available anymore)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM gittools/gitversion:5.1.3-linux-ubuntu-18.04-netcoreapp2.1
+FROM gittools/gitversion:5.5.1-linux-ubuntu.18.04-x64-netcoreapp3.1
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM gittools/gitversion:5.5.1-linux-ubuntu.18.04-x64-netcoreapp3.1
+FROM gittools/gitversion:5.3.1-linux-ubuntu.18.04-x64-netcoreapp2.1
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM gittools/gitversion:5.3.1-linux-ubuntu.18.04-x64-netcoreapp2.1
+FROM gittools/gitversion:5.5.1-linux-ubuntu.18.04-x64-netcoreapp3.1
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ if [ "${2,,}" == "true" ] ;then
     nocache="/nocache"
 fi
 
-dotnet /app/GitVersion.dll /github/workspace $nocache $nofetch /output buildserver > /version.txt; result=$?
+/tools/dotnet-gitversion /github/workspace $nocache $nofetch /output buildserver > /version.txt; result=$?
 
 buildserver="$(cat /version.txt)"
 
@@ -56,7 +56,7 @@ if [ $result -ne 0 ]; then
     exit $result
 fi
 
-dotnet /app/GitVersion.dll /github/workspace $nocache $nofetch /output json > /version.json; result=$?
+/tools/dotnet-gitversion /github/workspace $nocache $nofetch /output json > /version.json; result=$?
 
 # It doesn't look like GitVersion.dll returns anything but 0. This is here just in case this changes in the future.
 if [ $result -ne 0 ]; then


### PR DESCRIPTION
Hi,
over the christmas break the old gitversion stopped being available on docker hub, so the gh action was not able to build anymore. I've update the dockerfile with a newer version. As newer versions include a .net executable and not a dll anymore I updated the entrypoint-script accordingly. Tested on my fork with the included action and other projects that are using the action.
Hope this helps.

Cheers
Joscha